### PR TITLE
Fix typos (A dd, Cary over, prout)

### DIFF
--- a/src/cpp/ops/inplace_ops.cu
+++ b/src/cpp/ops/inplace_ops.cu
@@ -124,7 +124,7 @@ void copy_inplace(TensorView& out, const TensorView& other) {
 }
 
 void bind_inplace_ops_(py::module_& m) {
-    m.def("add_inplace", &add_inplace, "A dd elements inplace.", py::arg("x1"), py::arg("x2"));
+    m.def("add_inplace", &add_inplace, "Add elements inplace.", py::arg("x1"), py::arg("x2"));
     m.def("sub_inplace", &sub_inplace, "Subtract elements inplace.", py::arg("x1"), py::arg("x2"));
     m.def("mul_inplace", &mul_inplace, "Multiply elements inplace.", py::arg("x1"), py::arg("x2"));
     m.def("div_inplace", &div_inplace, "Divide elements inplace.", py::arg("x1"), py::arg("x2"));

--- a/src/cpp/ops/matmul.cu
+++ b/src/cpp/ops/matmul.cu
@@ -13,9 +13,9 @@ std::shared_ptr<Storage> _cpu_matmul(
     auto new_storage = Storage::allocate(numel, x1.storage->dtype(), Device::Cpu);
     auto* ptr1 = static_cast<const T*>(x1.storage->data());
     auto* ptr2 = static_cast<const T*>(x2.storage->data());
-    auto prout = static_cast<T*>(new_storage->data());
+    auto ptr_out = static_cast<T*>(new_storage->data());
     std::vector<py::ssize_t> loc(ndim);
-    for (py::ssize_t prout_idx = 0; prout_idx < numel; ++prout_idx) {
+    for (py::ssize_t ptr_out_idx = 0; ptr_out_idx < numel; ++ptr_out_idx) {
         // B, i, j -> derive B, i, c and B, c, j
         T acc = static_cast<T>(0.0);
         for (int c = 0; c < csize; ++c) {
@@ -31,7 +31,7 @@ std::shared_ptr<Storage> _cpu_matmul(
             }
             acc += ptr1[idx1] * ptr2[idx2];
         }
-        prout[prout_idx] = acc;
+        ptr_out[ptr_out_idx] = acc;
 
         py::ssize_t j = ndim - 1;
         while (j >= 0) { 

--- a/src/cpp/ops/unary_ops.cu
+++ b/src/cpp/ops/unary_ops.cu
@@ -41,7 +41,7 @@ std::shared_ptr<Storage> _cpu_sum(
                     }
                 }
                 out_data[i] = acc;
-                // Cary over out
+                // Carry over out
                 py::ssize_t k = ndim_out - 1;
                 while (k >= 0) { 
                     loc_out[k] += 1;


### PR DESCRIPTION
Fixes 3 typos reported in az-fouche/nanotorch#31:
- \src/cpp/ops/inplace_ops.cu:127\ — docstring 'A dd' → 'Add'
- \src/cpp/ops/unary_ops.cu:44\ — comment 'Cary' → 'Carry'  
- \src/cpp/ops/matmul.cu:98\ — variable name 'prout' → 'ptr_out'